### PR TITLE
issue 52: render bookdown automatically on push

### DIFF
--- a/.github/workflows/test-bookdown.yml
+++ b/.github/workflows/test-bookdown.yml
@@ -1,0 +1,60 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Test bookdown building on all branches
+name: test-bookdown
+on:
+  push:
+#    paths: '**.Rmd'
+  workflow_dispatch:
+jobs:
+  test-bookdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - name: install remotes
+        run: Rscript -e 'install.packages(c("remotes"))'
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
+      - name: install extra pkgs (suggests or used in rmd files)
+        run: Rscript -e 'install.packages(c("bookdown"))'
+
+      # only needed to check that this workflow does not run multiple times in a row
+      - name: get last commit msg
+        id: commit-msg
+        run: |
+          git tag
+          last_commit_msg=$(git log -1 --pretty=%B)
+          echo "::set-output name=msg::${last_commit_msg}"
+
+      - name: Cache bookdown results
+        uses: actions/cache@v2
+        with:
+          path: docs
+          key: bookdown-${{ hashFiles('**/*Rmd') }}
+          restore-keys: bookdown-
+
+      - name: Build site
+        run: Rscript -e 'bookdown::render_book(quiet = TRUE)'
+
+      - name: Save artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Bookdown_html
+          path: docs
+

--- a/.github/workflows/update-bookdown.yml
+++ b/.github/workflows/update-bookdown.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: install remotes
+        run: Rscript -e 'install.packages(c("remotes"))'
+
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Addresses #52. Also adds a missing step to update-bookdown that I discovered while working on this.

This workflow is the same as update-bookdown, but saves the artifact instead of deploying it. (@Bai-Li-NOAA , I will open an issue to add to the generalized bookdown workflow in ghactions4r - would be good to use those at some point instead.)

This job produces an artifact when successful, which is a zip file containing all files needed to generate the bookdown html site. Opening the index.html file will allow browsing the bookdown files like online or using the rstudio preview.

The workflow was tested in [github actions](https://github.com/NOAA-FIMS/collaborative_workflow/actions/runs/1995113084).