### PR TITLE
Update chapters 7 and 10 (#86 and #65)

### DIFF
--- a/07-contributor-guide.Rmd
+++ b/07-contributor-guide.Rmd
@@ -190,7 +190,7 @@ locally and before pushing changes to the remote branch.
 Run `devtoos::test()` locally before pushing tests to the remote feature branch. 
 * Running `styler::style_pkg()` to style R code locally and then push changes to 
 remote feature branch. If there are many changes, please do this in a separate commit.
-* Running `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
+* Running `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests. During development, run `devtools::build()` locally to build the package more frequently and faster.
 * Ensuring the code passes the call-r-cmd-check [GitHub Action workflow](#github-actions) on the remote feature branch.
 
 ## Commit Messages

--- a/10-testing.Rmd
+++ b/10-testing.Rmd
@@ -575,8 +575,9 @@ Multiple testthat tests can be put in the same file.
 ## Test case documentation template and examples
 
 A testing plan must be developed while designing (i.e., before coding)
-new FIMS features. This testing plan is documented using the test case
-documentation template below.
+new FIMS features or Rcpp modules. Please update the test cases in the [FIMS/tests/milestoneX_test_cases.md file](https://github.com/NOAA-FIMS/FIMS/tree/main/tests) (e.g., FIMS/tests/miletone1_test_cases.md). 
+This testing plan is documented using the test case documentation 
+template below. 
 
 ### Test case documentation template
 


### PR DESCRIPTION
This PR addresses issue #86 and #65
- Added in a sentence to the handbook how to use devtools::build() to compile code more frequently and faster.
- Added in a sentence to the handbook to show where to update test cases in FIMS repo