### PR TITLE
feat: add instructions on how to install gdb

### DIFF
--- a/06-developer-software-guide.Rmd
+++ b/06-developer-software-guide.Rmd
@@ -186,3 +186,22 @@ Sys.which("make") ##
 You will need to install `CMake` and `ninja` and validate you have the
 correct setup by following the steps outlined in the [test case
 template](#testing).
+
+### GDB debugger
+
+Windows users who use GoogleTest may need GDB debugger to see what is 
+going on inside of the program while it executes, or what the program is 
+doing at the moment it crashed. rtools40 includes the GDB debugger. The 
+steps below help install 64-bit version gdb.exe. 
+
+- Open Command Prompt and type `gdb`. If you see details of usage, GDB
+debugger is already in your PATH. If not, follow the instructions below
+to install GDB debugger and add it to your PATH. 
+- Install Rtools following the instructions [here](https://noaa-fims.github.io/collaborative_workflow/user-guide.html#windows-users) 
+- Open ~/rtools40/mingw64.exe to run commands in the mingw64 shell. Run 
+command `pacman -Sy mingw-w64-x86_64-gdb` to install 64-bit version 
+(more information can be found in [R on Windows FAQ](https://github.com/r-windows/docs/blob/master/faq.md#does-rtools40-include-a-debugger))
+- Type `Y` in the mingw64 shell to proceed with installation
+- Check whether ~/rtools40/mingw64/bin/gdb.exe exists or not
+- Add rtools40 to the PATH and you can check that the path is working 
+by running `which gdb` in a command window


### PR DESCRIPTION
This pull request addresses issue #99. A section on how to install GDB has been added to Chapter 6: developer software guide. The [test-bookdown check](https://github.com/NOAA-FIMS/collaborative_workflow/actions/runs/3414453056/jobs/5682429363) was successful.