### PR TITLE
Add installation instructions for Doxygen and Rtools

### DIFF
--- a/04-user-guide.Rmd
+++ b/04-user-guide.Rmd
@@ -17,7 +17,7 @@ The following software is required:
 
 ### Windows users
 
-- Rtools4 (available from [here](https://cran.r-project.org/bin/windows/Rtools/rtools40.html))
+- Rtools4.4 (available from [here](https://cran.r-project.org/bin/windows/Rtools/))
   - this likely requires IT support to install it on NOAA computers
   (or any without administrative accounts)
 

--- a/06-developer-software-guide.Rmd
+++ b/06-developer-software-guide.Rmd
@@ -205,3 +205,32 @@ command `pacman -Sy mingw-w64-x86_64-gdb` to install 64-bit version
 - Check whether ~/rtools40/mingw64/bin/gdb.exe exists or not
 - Add rtools40 to the PATH and you can check that the path is working 
 by running `which gdb` in a command window
+
+
+### Doxygen
+
+To build C++ documentation website for FIMS, a documentation 
+generator Doxygen needs to be installed. Doxygen automates the generation of 
+documentation from source code comments. To install Doxygen, please follow the 
+instructions [here](https://www.doxygen.nl/manual/install.html) to install 
+Doxygen on various operating systems. Below are steps to install 64-bit version of
+Doxygen 1.11.0 on Windows. 
+
+- Download [doxygen-1.11.0.windows.x64.bin.zip](https://www.doxygen.nl/files/doxygen-1.11.0.windows.x64.bin.zip) 
+and extract the applications to `Documents\Apps\Doxygen` or other preferred folder.
+
+- Add Doxygen to the PATH by following similar instructions [here](https://noaa-fims.github.io/collaborative_workflow/testing.html#adding-cmake-and-ninja-to-your-path-on-windows).
+
+- Open a command window and run `where doxygen` to check if Doxygen is
+added to the PATH.
+
+- Two commands on the command line are needed to generate C++ documentation 
+for FIMS locally:
+
+```bash
+cmake -S. -B build -G Ninja
+cmake -- build build
+```
+
+
+

--- a/06-developer-software-guide.Rmd
+++ b/06-developer-software-guide.Rmd
@@ -164,13 +164,13 @@ If not, you will need to check that the compiler is on the path. The
 easiest way to do so is by creating a text file .Renviron in your 
 Documents folder which contains the following line:
 ```
-PATH="${RTOOLS40_HOME}\usr\bin;${PATH}"
+PATH="${RTOOLS44_HOME}\usr\bin;${PATH}"
 ```
 
 You can do this with a text editor, or from `R` like so (note that in 
 `R` code you need to escape backslashes):
 ```{r eval=FALSE}
-write('PATH="${RTOOLS40_HOME}\\usr\\bin;${PATH}"', file = "~/.Renviron", append = TRUE)
+write('PATH="${RTOOLS44_HOME}\\usr\\bin;${PATH}"', file = "~/.Renviron", append = TRUE)
 ```
 
 Restart R, and verify that make can be found, which should show the path
@@ -178,7 +178,7 @@ to your Rtools installation.
 
 ```{r eval=FALSE}
 Sys.which("make") ##
-"C:\\rtools40\\usr\\bin\\make.exe" 
+"C:\\rtools44\\usr\\bin\\make.exe" 
 ```
 
 ### GoogleTest
@@ -191,19 +191,19 @@ template](#testing).
 
 Windows users who use GoogleTest may need GDB debugger to see what is 
 going on inside of the program while it executes, or what the program is 
-doing at the moment it crashed. rtools40 includes the GDB debugger. The 
+doing at the moment it crashed. rtools44 includes the GDB debugger. The 
 steps below help install 64-bit version gdb.exe. 
 
 - Open Command Prompt and type `gdb`. If you see details of usage, GDB
 debugger is already in your PATH. If not, follow the instructions below
 to install GDB debugger and add it to your PATH. 
 - Install Rtools following the instructions [here](https://noaa-fims.github.io/collaborative_workflow/user-guide.html#windows-users) 
-- Open ~/rtools40/mingw64.exe to run commands in the mingw64 shell. Run 
+- Open ~/rtools44/mingw64.exe to run commands in the mingw64 shell. Run 
 command `pacman -Sy mingw-w64-x86_64-gdb` to install 64-bit version 
 (more information can be found in [R on Windows FAQ](https://github.com/r-windows/docs/blob/master/faq.md#does-rtools40-include-a-debugger))
 - Type `Y` in the mingw64 shell to proceed with installation
-- Check whether ~/rtools40/mingw64/bin/gdb.exe exists or not
-- Add rtools40 to the PATH and you can check that the path is working 
+- Check whether ~/rtools44/mingw64/bin/gdb.exe exists or not
+- Add rtools44 to the PATH and you can check that the path is working 
 by running `which gdb` in a command window
 
 


### PR DESCRIPTION
This PR adds instructions on how to install Doxygen and updates the information related to Rtools, upgrating from Rtools40 to Rtools44. 

Note that Rtools43 is not compatible as it is used for R 4.3.x. FIMS requires TMB, which in turn depends on the Matrix package, and Matrix requires R version 4.4.0 or higher.