### PR TITLE
doc(07-contributor-guide): Simplifies branch names

### DIFF
--- a/07-contributor-guide.Rmd
+++ b/07-contributor-guide.Rmd
@@ -208,19 +208,11 @@ The following suggestions will help ensure optimal performance of the trunk-base
 
 ### Branch Naming Conventions
 
-Example: **feat-issue-3-R-package-skeleton**
+Example: **R-pkg-skeleton**
 
-1. When creating a branch, start the branch name with a group word:
+1. Keep it brief
 
-  - **bug**: bug fix
-
-  - **feat**: new feature
-
-2. Use issue tracker ID in branch name
-
-3. Include brief description
-
-3. Use a hyphen as separators
+1. Use a hyphen as separators
 
 ### git workflow
 


### PR DESCRIPTION
Remove much of the guidance around branch naming because it was not being used and was overly prescriptive. Kept just two guidance notes.

Close #134