### PR TITLE
Update issue tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
-labels: bug
+title: "[BUG]: "
+labels: ["kind: bug", "status: triage_needed"]
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: ["status: triage_needed"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/handbook-addition.md
+++ b/.github/ISSUE_TEMPLATE/handbook-addition.md
@@ -2,7 +2,7 @@
 name: Handbook addition
 about: Suggest new content for this handbook
 title: "[NEW SECTION]"
-labels: ''
+labels: ["status: triage_needed"]
 
 ---
 

--- a/07-contributor-guide.Rmd
+++ b/07-contributor-guide.Rmd
@@ -128,12 +128,15 @@ To fork and then clone a repository, follow the [Github Documentation for forkin
 
 ## Issue Tracking
 
-Use of the GitHub issue tracker is key to keeping everyone informed and prioritizing key tasks. All future projects, ideas, concerns, development,
-etc. must be documented in an issue before the code is altered. Issues should be filed and tagged prior to any code changes whether the change
-pertains to a bug or the development of a feature. At a minimum, all issues will be labeled with a future version number. Bugs with immediate fixes will
-be assigned to the current version number augmented for a hot fix and development will be based on code in the trunk. All other issues will be
-assigned to a future version and development will be based on version branches. That is, changes to the code for version 3.3 cannot start until there is a branch
-for version 3.3. This will minimize stale code and large merge conflicts.
+Use of the GitHub issue tracker is key to keeping everyone informed and
+prioritizing key tasks. All future projects, ideas, concerns, development,
+etc. must be documented in an issue before the code is altered. Issues should
+be filed and tagged prior to any code changes whether the change pertains to a
+bug or the development of a feature. Issues are automatically tagged with the
+`status: triage_needed` tag and placed on the [Issue Triage
+Board](https://github.com/orgs/NOAA-FIMS/projects/21). Issues will subsequently
+be labeled and given an assignee and milestone by whoever is in charge of the
+Triage Board.
 
 ## Reporting Bugs
 


### PR DESCRIPTION
Close #131 by adding text to 07 of the workflow website about the Triage Board complete with a link. And, add labels to new issues of "status: triage_needed" to increase consistency with the FIMS repo.