### PR TITLE
159 cache action version update

### DIFF
--- a/.github/workflows/test-bookdown.yml
+++ b/.github/workflows/test-bookdown.yml
@@ -47,7 +47,7 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Cache bookdown results
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: docs
           key: bookdown-${{ hashFiles('**/*Rmd') }}
@@ -57,7 +57,7 @@ jobs:
         run: Rscript -e 'bookdown::render_book(quiet = TRUE)'
 
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Bookdown_html
           path: docs

--- a/.github/workflows/test-bookdown.yml
+++ b/.github/workflows/test-bookdown.yml
@@ -47,7 +47,7 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Cache bookdown results
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: docs
           key: bookdown-${{ hashFiles('**/*Rmd') }}

--- a/.github/workflows/update-bookdown.yml
+++ b/.github/workflows/update-bookdown.yml
@@ -48,7 +48,7 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Cache bookdown results
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: docs
           key: bookdown-${{ hashFiles('**/*Rmd') }}

--- a/.github/workflows/update-bookdown.yml
+++ b/.github/workflows/update-bookdown.yml
@@ -48,7 +48,7 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Cache bookdown results
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: docs
           key: bookdown-${{ hashFiles('**/*Rmd') }}


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Update the workflow actions for caching and artifact upload

# How have you implemented the solution?
* Changed the `test-bookdown.yml` and `update-bookdown.yml` files to use the new versions of these actions

# Does the PR impact any other area of the project, maybe another repo?
* This is a great question.  It is definitely possible for other repos to reference the workflows in this repo.  I do not know how to see what other repos reference the workflows in this repo.  OTOH, this upgrade "just worked", so hopefully any referencing repos will not experience any disruption.

Closes #159 .  Tested using the usual [contribution workflow](https://noaa-fims.github.io/collaborative_workflow/index.html#edit-and-preview-book-changes).  Attached is a screenshot of the working book after downloading the github-built .zip artifact.

![Screenshot 2025-03-12 151513](https://github.com/user-attachments/assets/d79559ef-53ae-4bad-9d30-7e26af3a050a)

